### PR TITLE
Symfony component Serializer support for YAML config property mapping

### DIFF
--- a/aws_sqs_entity.api.php
+++ b/aws_sqs_entity.api.php
@@ -30,5 +30,47 @@ function hook_aws_sqs_entity_send_item($type, $entity, $op) {
 }
 
 /**
+ * Allows modules to declare paths to their own property mapping YAML configs.
+ *
+ * @return array
+ *   An associative array of full system paths to directories containing YAML
+ *   property mapper configs.
+ *
+ * The first config file matching the requested pattern will end the search, so
+ * if you wish to take precedence over another module's config file for the same
+ * bundle, implement hook_module_implements_alter().
+ *
+ * Config file name pattern must be:
+ * - aws_sqs_entity.property_mapper.{ENTITY_TYPE}.{BUNDLE}.yml
+ *
+ * Each YAML file should contain:
+ * - itemType: The name of the external API resource.
+ * - field_map: An associative array of fields or properties on the Drupal
+ *   Entity, keyed by the mapped external API resource fields. Values may be
+ *   an associative array of nested field_map key/value pairs.
+ *
+ * Example YAML config:
+ * - my_module/path/to/config/aws_sqs_entity.property_mapper.node.article.yaml:
+ * @code
+ * itemType: post
+ * field_map:
+ *   uuid: uuid
+ *   revision: vid
+ *   title: title
+ *   tags: field_tags
+ *   published: status
+ *   image: field_image
+ *   description: body
+ *   nestedMap:
+ *     nested1: uuid
+ *     nested2: vid
+ *     nested3: title
+ * @endcode
+ */
+function hook_aws_sqs_entity_property_mapper_config_paths() {
+  return [DRUPAL_ROOT . '/' . drupal_get_path('module', 'my_module') . '/path/to/config'];
+}
+
+/**
  * @} End of "addtogroup hooks".
  */

--- a/aws_sqs_entity.api.php
+++ b/aws_sqs_entity.api.php
@@ -82,8 +82,8 @@ function hook_aws_sqs_entity_property_mapper_config_paths() {
  */
 function hook_aws_sqs_entity_value_wrapper_normalizers() {
   return [
-    '\Drupal\my_module\Normalizer\EndpointOneNormalizer',
-    '\Drupal\my_module\Normalizer\EndpointTwoNormalizer',
+    new \Drupal\my_module\Normalizer\EndpointOneNormalizer(),
+    new \Drupal\my_module\Normalizer\EndpointTwoNormalizer(),
   ];
 }
 

--- a/aws_sqs_entity.api.php
+++ b/aws_sqs_entity.api.php
@@ -72,5 +72,21 @@ function hook_aws_sqs_entity_property_mapper_config_paths() {
 }
 
 /**
+ * Allows modules to declare property mapper normalizers.
+ *
+ * @return array
+ *   An array of fully namespaced normalizer class names. Must extend
+ *   AbstractEntityValueWrapperNormalizer.
+ *
+ * @see \Drupal\aws_sqs_entity\Normalizer\AbstractEntityValueWrapperNormalizer
+ */
+function hook_aws_sqs_entity_value_wrapper_normalizers() {
+  return [
+    '\Drupal\my_module\Normalizer\EndpointOneNormalizer',
+    '\Drupal\my_module\Normalizer\EndpointTwoNormalizer',
+  ];
+}
+
+/**
  * @} End of "addtogroup hooks".
  */

--- a/aws_sqs_entity.info
+++ b/aws_sqs_entity.info
@@ -4,3 +4,4 @@ dependencies[] = aws_sqs
 dependencies[] = composer_manager
 configure = admin/config/system/aws-sqs-entity
 core = 7.x
+php = 7

--- a/src/Entity/PropertyMapper.php
+++ b/src/Entity/PropertyMapper.php
@@ -39,7 +39,7 @@ class PropertyMapper extends CrudQueue {
    *
    * Additionally instantiate variables on this class needed for schema mapping.
    */
-  public function __construct($name, $type, $entity, $op) {
+  public function __construct(string $name, string $type, \stdClass $entity, string $op) {
     // Bail now if we don't have Entity API enabled.
     $this->validateClass();
 
@@ -136,7 +136,7 @@ class PropertyMapper extends CrudQueue {
    * @param $data
    *   The return value of getMessageBody().
    */
-  protected function yamlPropertyMapper($fields, &$data) {
+  protected function yamlPropertyMapper(array $fields, array &$data) {
     foreach ($fields as $key => $field) {
       $value = NULL;
 
@@ -208,7 +208,7 @@ class PropertyMapper extends CrudQueue {
    * @see getMessageBody()
    * @see AwsSqsQueue::serialize()
    */
-  protected static function serialize($data) {
+  protected static function serialize(array $data) {
     $serializer = new Serializer([], [new JsonEncoder()]);
     return $serializer->encode($data, 'json');
   }

--- a/src/Entity/PropertyMapper.php
+++ b/src/Entity/PropertyMapper.php
@@ -120,7 +120,9 @@ class PropertyMapper extends CrudQueue {
   protected function getMessageBody() {
     $data = [];
 
-    $this->yamlPropertyMapper($this->config['field_map'], $data);
+    if (isset($this->config['field_map'])) {
+      $this->yamlPropertyMapper($this->config['field_map'], $data);
+    }
 
     return $data;
   }

--- a/src/Entity/PropertyMapper.php
+++ b/src/Entity/PropertyMapper.php
@@ -152,7 +152,7 @@ class PropertyMapper extends CrudQueue {
 
       // Now that we have the Drupal Entity field/property, get each field
       // item(s) value.
-      if ($this->fieldExists($field)) {
+      if (isset($this->wrapper->$field)) {
         $value = $this->EntityMetadataWrapper($this->wrapper->$field);
       }
 

--- a/src/Entity/PropertyMapper.php
+++ b/src/Entity/PropertyMapper.php
@@ -39,7 +39,7 @@ class PropertyMapper extends CrudQueue {
    *
    * Additionally instantiate variables on this class needed for schema mapping.
    */
-  public function __construct(string $name, string $type, \stdClass $entity, string $op) {
+  public function __construct($name, $type, $entity, $op) {
     // Bail now if we don't have Entity API enabled.
     $this->validateClass();
 
@@ -138,7 +138,7 @@ class PropertyMapper extends CrudQueue {
    * @param $data
    *   The return value of getMessageBody().
    */
-  protected function yamlPropertyMapper(array $fields, array &$data) {
+  protected function yamlPropertyMapper($fields, &$data) {
     foreach ($fields as $key => $field) {
       $value = NULL;
 
@@ -212,7 +212,7 @@ class PropertyMapper extends CrudQueue {
    * @see getMessageBody()
    * @see AwsSqsQueue::serialize()
    */
-  protected static function serialize(array $data) {
+  protected static function serialize($data) {
     $serializer = new Serializer([], [new JsonEncoder()]);
     return $serializer->encode($data, 'json');
   }

--- a/src/Entity/PropertyMapper.php
+++ b/src/Entity/PropertyMapper.php
@@ -188,6 +188,8 @@ class PropertyMapper extends CrudQueue {
   /**
    * @param \EntityValueWrapper $wrapper
    * @return array|object|\Symfony\Component\Serializer\Normalizer\scalar
+   *
+   * @todo Ensure normalizers extend AbstractEntityValueWrapperNormalizer.
    */
   protected function EntityValueWrapper(\EntityValueWrapper $wrapper) {
     $normalizers = module_invoke_all('hook_aws_sqs_entity_value_wrapper_normalizers', $this->wrapper);

--- a/src/Entity/PropertyMapper.php
+++ b/src/Entity/PropertyMapper.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Drupal\aws_sqs_entity\Entity;
+
+use \Symfony\Component\Yaml\Yaml;
+use \Symfony\Component\Serializer\Serializer;
+use \Symfony\Component\Serializer\Encoder\JsonEncoder;
+use \Drupal\aws_sqs_entity\Normalizer\EntityMetadataWrapperNormalizer;
+
+/**
+ * Class PropertyMapper
+ * @package Drupal\aws_sqs_entity\Entity
+ *
+ * Maps to YAML config, and normalizes Entity data before sending to the queue.
+ */
+class PropertyMapper extends CrudQueue {
+
+  /**
+   * @var string
+   */
+  protected $bundle;
+
+  /**
+   * @var array
+   */
+  protected $fieldMap = [];
+
+  /**
+   * @var \EntityDrupalWrapper
+   */
+  protected $wrapper;
+
+  /**
+   * @var array
+   */
+  protected $config = [];
+
+  /**
+   * {@inheritdoc}
+   *
+   * Additionally instantiate variables on this class needed for schema mapping.
+   */
+  public function __construct($name, $type, $entity, $op) {
+    // Bail now if we don't have Entity API enabled.
+    $this->validateClass();
+
+    // Allow parent method to set vars so we don't have to again here.
+    parent::__construct($name, $type, $entity, $op);
+
+    $this->setFieldMap();
+    $this->setWrapper();
+    $this->setBundle();
+    $this->setConfig();
+  }
+
+  protected function validateClass() {
+    if (!module_exists('entity')) {
+      throw new \Exception('Entity API must be enabled to use this class: ' . __CLASS__);
+    }
+  }
+
+  protected function setFieldMap() {
+    $this->fieldMap = field_info_field_map();
+  }
+
+  protected function setWrapper() {
+    $this->wrapper = entity_metadata_wrapper($this->type, $this->entity);
+  }
+
+  protected function setBundle() {
+    $this->bundle = $this->wrapper->getBundle();
+  }
+
+  /**
+   * Sets the config for the current bundle given a matching filepath.
+   *
+   * @see hook_aws_sqs_entity_property_mapper_config_paths()
+   */
+  protected function setConfig() {
+    $paths = module_invoke_all('aws_sqs_entity_property_mapper_config_paths');
+    $file_pattern = join('.', ['aws_sqs_entity', 'property_mapper', $this->type, $this->bundle, 'yml']);
+    foreach ($paths as $path) {
+      $filename = join('/', [$path, $file_pattern]);
+      if (file_exists($filename)) {
+        $this->config = Yaml::parse(file_get_contents($filename));
+        // The first file found wins.
+        break;
+      }
+    }
+  }
+
+  /**
+   * Iterates over all config keys to find Drupal Entity mapped values.
+   *
+   * @param $fields
+   *   See $field_map param of setConfig().
+   * @param $data
+   *   The return value of getMessageBody().
+   */
+  protected function iterateConfigKeys($fields, &$data) {
+    foreach ($fields as $key => $field) {
+      $value = NULL;
+
+      // Add recursion to handle YAML config field_map values that are
+      // associative arrays of field values (example, customFields).
+      if (!is_string($field) && is_array($field)) {
+        $data[$key] = [];
+        $this->iterateConfigKeys($field, $data[$key]);
+        continue;
+      }
+
+      // Now that we have the Drupal Entity field/property, get each field item
+      // delta value.
+      // @todo This does not yet allow properly handling plugin normalization.
+      //   But move one fully working step at a time.
+      if ($this->fieldExists($field)) {
+        if ($this->isListWrapper($field)) {
+          foreach ($this->wrapper->$field->getIterator() as $delta => $itemWrapper) {
+            $value[$delta] = $this->normalizeItemValue($itemWrapper);
+          }
+        }
+        else {
+          // This is an EntityValueWrapper.
+          $value = $this->normalizeItemValue($this->wrapper->$field);
+        }
+      }
+
+      $data[$key] = $value;
+    }
+  }
+
+  /**
+   * @param \EntityMetadataWrapper $itemWrapper
+   *
+   * @todo Discover correct plugins.
+   */
+  protected function normalizeItemValue($itemWrapper) {
+    // @todo Normalize this.
+//    return $itemWrapper->value();
+
+    $normalizers = module_invoke_all('aws_sqs_entity_normalizers', $itemWrapper);
+    $serializer = new Serializer($normalizers, []);
+    return $serializer->normalize($itemWrapper);
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * Overrides parent method for Entity data => API schema mapping.
+   *
+   * @todo Note that a lot of this work is related to serialization, so sounds
+   *   like it should be in this::serialize(), however the $data param is sent
+   *   to ::serialize, so we would just ignore that entirely. Perhaps that is
+   *   less confusing though, given the fact that Symfony/Component/Serializer
+   *   handles the JSON encoding in the same operation as normalizing.
+   *   Another problem with doing this in ::serialize() is it must be static
+   *   (because of inheritance), which means if it calls ::iterateConfigKeys()
+   *   that would need to be refactored to be static as well. As an alternative,
+   *   we could do all the serializing/normalizing work in this method, and
+   *   ::serialize() could be a straight pass-through. We would just need to
+   *   document that well, so it's clear why we have this semantic mismatch.
+   *
+   * @see CrudQueue::getMessageBody()
+   */
+  protected function getMessageBody() {
+    $data = [];
+    $this->iterateConfigKeys($this->config['field_map'], $data);
+
+    $normalizers = [new EntityMetadataWrapperNormalizer()];
+    $encoders = [new JsonEncoder()];
+    $serializer = new Serializer($normalizers, $encoders);
+    return $serializer->serialize($data, 'json');
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * The $data array at this point should match the final YAML map, and contain
+   * values from EntityMetadataWrapper item wrapper ::value().
+   *
+   * Use Symfony Serializer component instead of json_encode().
+   * Also normalize the $data (Drupal Entity) object before JSON encoding.
+   *
+   * @todo Identify how to bypass stdClass issues with Serializer::serialize()
+   *   method (currently ObjectNormalizer does not work properly with stdClass).
+   *   Until then, use only Serializer::encode().
+   */
+  protected static function serialize($data, $context) {
+    $encoders = [new JsonEncoder()];
+    $serializer = new Serializer([], $encoders);
+    return $serializer->encode($data, 'json');
+  }
+
+
+
+  /**
+   * @todo We may not need this method. Keep commented for now in case we do.
+   */
+//  protected function getFieldType($field_name) {
+//    return $this->fieldMap[$field_name]['type'];
+//  }
+
+}

--- a/src/Normalizer/AbstractEntityValueWrapperNormalizer.php
+++ b/src/Normalizer/AbstractEntityValueWrapperNormalizer.php
@@ -25,9 +25,19 @@ class AbstractEntityValueWrapperNormalizer implements NormalizerInterface {
 
   /**
    * {@inheritdoc}
+   *
+   * We must also support instances of EntityStructureWrapper, or item wrappers
+   * for field types such as taxonomy_term or entity references would not be
+   * supported by this normalizer, and get stuck in very deeply nested loops
+   * of the "instanceof \Traversable" check within Serializer::normalize().
+   *
+   * @todo Consider renaming this base class, since we now support not only
+   *   \EntityValueWrapper but now also \EntityStructureWrapper.
+   *
+   * @see \Symfony\Component\Serializer\Serializer::normalize()
    */
   public function supportsNormalization($data, $format = null) {
-    return $data instanceof \EntityValueWrapper;
+    return $data instanceof \EntityValueWrapper || $data instanceof \EntityStructureWrapper;
   }
 
 }

--- a/src/Normalizer/AbstractEntityValueWrapperNormalizer.php
+++ b/src/Normalizer/AbstractEntityValueWrapperNormalizer.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\aws_sqs_entity\Normalizer;
+
+use \Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class AbstractEntityValueWrapperNormalizer implements NormalizerInterface {
+
+  /**
+   * {@inheritdoc}
+   *
+   * Each normalizer that extends this class should return an actual value, not
+   * another EntityValueWrapper (which would render as an empty object when JSON
+   * encoded).
+   *
+   * @param array $context
+   *   See $context param of PropertyMapper::serialize.
+   *
+   * @see \Drupal\aws_sqs_entity\Entity\PropertyMapper::serialize()
+   */
+  public function normalize($object, $format = null, array $context = array()) {
+    // Example unaltered return value from \EntityValueWrapper object.
+    return $object->value();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function supportsNormalization($data, $format = null) {
+    return $data instanceof \EntityValueWrapper;
+  }
+
+}


### PR DESCRIPTION
Note this PR explicitly requires PHP 7, mainly because I want type hinting, short array bracket syntax, and other PHP 7 niceties and don't feel like backporting to older versions of PHP unless there's some really good reason to do so.