### PR TITLE
US40361: Add data for logging, catch exceptions

### DIFF
--- a/aws_sqs_entity.api.php
+++ b/aws_sqs_entity.api.php
@@ -13,18 +13,26 @@
 /**
  * Allows modules to respond after an item is sent to the AWS Queue.
  *
- * @param string $type
- *   The Entity type.
- * @param object $entity
- *   The Entity object.
- * @param string $op
- *   The Entity CRUD operation. Can be one of:
- *   - insert
- *   - update
- *   - delete
+ * @param array $item_info
+ *   An array of contextual data with the following keys:
+ *     'type' => Entity type
+ *     'entity' => Entity object
+ *     'op' => Operation: 'insert', 'update', or 'delete'
+ *     'result' => Boolean representing success or failure
+ *     'data' => The message data
+ *     'message' => [
+ *       'attributes' => SQS Message attributes
+ *       'id' => SQS Message ID
+ *     ],
+ *     'error' => [ [ONLY PRESENT IN ERROR CASES]
+ *       'response_message' => Response message
+ *       'response_code' => Response code
+ *       'response_raw' => Raw response data
+ *     ],
  */
-function hook_aws_sqs_entity_send_item($type, $entity, $op) {
+function hook_aws_sqs_entity_send_item($item_info) {
   // Example: Set custom message.
+  extract($item_info);
   $args = array('%op' => $op, '%type' => $type, '%title' => entity_label($type, $entity));
   drupal_set_message(t('Congrats! You posted a SQS %op message for the %type: %title', $args));
 }


### PR DESCRIPTION
Currently, if the AWS connection fails, we can see fatal PHP errors. So I borrowed some working try/catch logic from Concerto CMS.

Also added more data to hand off to logging, which results in changing the function signature of `hook_aws_sqs_entity_send_item()`. If there is anything already implementing this hook, it would be a breaking change.

@scottrigby please let me know your thoughts, thx!