### PR TITLE
Make marshalWrapperClass public so other classes can use it

### DIFF
--- a/src/Entity/PropertyMapper.php
+++ b/src/Entity/PropertyMapper.php
@@ -381,7 +381,7 @@ class PropertyMapper extends CrudQueue {
    * @see entity_metadata_site_wrapper()
    * @see entity_metadata_system_entity_property_info()
    */
-  protected function marshalWrapperClass(\EntityMetadataWrapper $wrapper, array &$context) {
+  public function marshalWrapperClass(\EntityMetadataWrapper $wrapper, array &$context) {
     $class = get_class($wrapper);
     if (is_callable([$this, $class])) {
       $this->{$class}($wrapper, $context);


### PR DESCRIPTION
Once this really worked I thought this was so generically useful, it could become it's own class and/or project. For now, just making this method public.