### PR TITLE
NFR: Add config-getter, allow queue override

### DIFF
--- a/aws_sqs_entity.module
+++ b/aws_sqs_entity.module
@@ -58,10 +58,15 @@ function aws_sqs_entity_entity_delete($entity, $type) {
  *   The CRUD operation from hook_entity_OPERATION().
  * @param bool $skip_rules
  *   Optionally skip CrudQueue::checkRules().
+ *
+ * @return bool Whether the entity published or not.
  */
 function aws_sqs_entity_crud($entity, $type, $op, $skip_rules = FALSE) {
-  if ($queue = CrudQueue::getQueue($type, $entity, $op, $skip_rules)) {
-    $queue->sendItem();
+  if ($queue = CrudQueue::getQueue($type, $entity, $op)) {
+    if (!$skip_rules && !$queue::checkRules($type, $entity, $op)) {
+      return FALSE;
+    }
+    return $queue->sendItem();
   }
 }
 

--- a/aws_sqs_entity.module
+++ b/aws_sqs_entity.module
@@ -48,7 +48,7 @@ function aws_sqs_entity_entity_delete($entity, $type) {
 }
 
 /**
- * Wrapper for our Entity CRUD hook implementations.
+ * AWS SQS Entity CRUD action wrapper.
  *
  * @param object $entity
  *   The CRUD-triggered Entity.

--- a/src/Entity/CrudQueue.php
+++ b/src/Entity/CrudQueue.php
@@ -120,19 +120,16 @@ class CrudQueue extends \AwsSqsQueue {
    *   - insert
    *   - update
    *   - delete
-   * @param bool $skip_rules
-   *   Optionally skip CrudQueue::checkRules().
    *
    * @see \Drupal\aws_sqs_entity\Entity\CrudQueue::__construct()
    *
    * @return \Drupal\aws_sqs_entity\Entity\CrudQueue|false
    */
-  static public function getQueue(string $type, $entity, string $op, bool $skip_rules = TRUE) {
+  static public function getQueue(string $type, $entity, string $op) {
     $class = variable_get('aws_sqs_entity_queue_class', AWS_SQS_ENTITY_QUEUE_CLASS_DEFAULT);
     $name = variable_get('aws_sqs_entity_queue_name');
-    $rules_pass = $skip_rules ? TRUE : self::checkRules($type, $entity, $op);
 
-    if (!$class || !$name || !$rules_pass) {
+    if (!$class || !$name) {
       return FALSE;
     }
 

--- a/src/Entity/PropertyMapper.php
+++ b/src/Entity/PropertyMapper.php
@@ -88,8 +88,22 @@ class PropertyMapper extends CrudQueue {
    * @see hook_aws_sqs_entity_property_mapper_config_paths()
    */
   protected function setConfig() {
+    $this->config = self::getConfigFile($this->type, $this->bundle);
+  }
+
+  /**
+   * Get the config for the current bundle.
+   *
+   * @param string $type
+   *   The entity type.
+   * @param string $bundle
+   *   The entity bundle.
+   *
+   * @return array|null
+   */
+  public static function getConfigFile($type, $bundle) {
     $paths = module_invoke_all('aws_sqs_entity_property_mapper_config_paths');
-    $file_pattern = join('.', [$this->type, $this->bundle, 'yml']);
+    $file_pattern = join('.', [$type, $bundle, 'yml']);
     foreach ($paths as $path) {
       $filename = join('/', [$path, $file_pattern]);
       if (file_exists($filename)) {
@@ -98,9 +112,9 @@ class PropertyMapper extends CrudQueue {
         //   fail. If we need this, it appears that we may have to add some
         //   special string value to match to provide this support, such as
         //   "EMPTY_OBJECT".
-        $this->config = Yaml::parse(file_get_contents($filename));
+
         // The first file found wins.
-        break;
+        return Yaml::parse(file_get_contents($filename));
       }
     }
   }

--- a/src/Entity/PropertyMapper.php
+++ b/src/Entity/PropertyMapper.php
@@ -88,7 +88,7 @@ class PropertyMapper extends CrudQueue {
    * @see hook_aws_sqs_entity_property_mapper_config_paths()
    */
   protected function setConfig() {
-    $this->config = self::getConfigFile($this->type, $this->bundle);
+    $this->config = self::getConfig($this->type, $this->bundle);
   }
 
   /**
@@ -101,7 +101,7 @@ class PropertyMapper extends CrudQueue {
    *
    * @return array|null
    */
-  public static function getConfigFile($type, $bundle) {
+  public static function getConfig($type, $bundle) {
     $paths = module_invoke_all('aws_sqs_entity_property_mapper_config_paths');
     $file_pattern = join('.', [$type, $bundle, 'yml']);
     foreach ($paths as $path) {


### PR DESCRIPTION
Does 2 things in 2 commits:

1. Add a getConfigFile() method:
1.1 Maybe someone else wants to get the YML for an entity. Let's make it easy for them.

2. Move checking the rules out of getting the queue:
2.1 The module is kind enough to allow us to override `CrudQueue`, and use another class. In that new class, we may want to implement our own `getRules()` or `checkRules()`. Let's make `getQueue()` really just *get* the queue, and do other operations later, in case it is a custom queue.