### PR TITLE
[on hold] Load the uncached entity

### DIFF
--- a/src/Entity/CrudQueue.php
+++ b/src/Entity/CrudQueue.php
@@ -139,7 +139,8 @@ class CrudQueue extends \AwsSqsQueue {
     // foreach getIterator(), or on value() - only when CRUD-triggered.
     // @todo Investigate this patch: https://www.drupal.org/node/1013428
     list($id) = entity_extract_ids($type, $entity);
-    $entity = entity_load_single($type, $id);
+    $uncached_entity = entity_load($type, [$id], [], TRUE);
+    $entity = reset($uncached_entity);
 
     // @todo Pass any overloaded args.
     return new $class($name, $type, $entity, $op);


### PR DESCRIPTION
I am seeing situations where the `$entity` that comes into `getQueue()` has different values than the `$entity` returned by `entity_load_single()`. In my case, the most important different value is the `$entity->status`. Resetting the node cache fixes it.

@scottrigby 