### PR TITLE
Have this module run crud hooks last

### DIFF
--- a/aws_sqs_entity.module
+++ b/aws_sqs_entity.module
@@ -83,7 +83,13 @@ function aws_sqs_entity_aws_sqs_entity_value_wrapper_normalizers() {
  * Implements hook_module_implements_alter().
  */
 function aws_sqs_entity_module_implements_alter(&$implementations, $hook) {
-  if ($hook == 'aws_sqs_entity_value_wrapper_normalizers') {
+  $hooks = [
+    'aws_sqs_entity_value_wrapper_normalizers',
+    'entity_insert',
+    'entity_update',
+    'entity_delete',
+  ];
+  if (in_array($hook, $hooks)) {
     // Move aws_sqs_entity_aws_sqs_entity_value_wrapper_normalizers() to the end
     // of the list, so that other normalizers can fire first, and if no
     // supporting normalizer is found, we fall back to


### PR DESCRIPTION
There are some very important hooks that should run before this module tries to publish up-to-date data:

![evaluate expression 2017-12-11 13-40-49](https://user-images.githubusercontent.com/1637613/33848776-c140e628-de7c-11e7-9c32-598a006bcb6c.png)
