### PR TITLE
Validate the parent entity value before set the final_source_prop_value

### DIFF
--- a/src/Entity/PropertyMapper.php
+++ b/src/Entity/PropertyMapper.php
@@ -456,7 +456,15 @@ class PropertyMapper extends CrudQueue {
       }
     }
     else {
-      $context['final_source_prop_value'] = $this->normalize($wrapper, $context);
+      // Need to check the parent entity is null or not. in order to prevent
+      // error message, EntityMetadataWrapperException: Unable to get the data
+      // property uuid as the parent data structure is not set.
+      if (!is_null($wrapper->info()['parent']->value())) {
+        $context['final_source_prop_value'] = $this->normalize($wrapper, $context);
+      }
+      else {
+        $context['final_source_prop_value'] = null;
+      }
     }
   }
 

--- a/src/Entity/PropertyMapper.php
+++ b/src/Entity/PropertyMapper.php
@@ -456,13 +456,13 @@ class PropertyMapper extends CrudQueue {
       }
     }
     else {
-      // Need to check the parent entity is null or not. in order to prevent
-      // error message, EntityMetadataWrapperException: Unable to get the data
-      // property uuid as the parent data structure is not set.
-      if (!is_null($wrapper->info()['parent']->value())) {
+      // Try to catch the EntityMetadataWrapperException, and set the
+      // 'final_source_prop_value' to null, so prevent the undefined entity
+      // property error message from null entity.
+      try {
         $context['final_source_prop_value'] = $this->normalize($wrapper, $context);
       }
-      else {
+      catch (\EntityMetadataWrapperException $e) {
         $context['final_source_prop_value'] = null;
       }
     }


### PR DESCRIPTION
In CMS, some field is set to entity reference and this field value also can have empty value since it is optional field.  This case, we often get error message of `EntityMetadataWrapperException: Unable to get the data property uuid ... `  In order to fix all these empty entity reference case handling, I request to review the updates.  Please let me know your opinion.

cc to @jfrederick 
