### PR TITLE
update getConfig logic for Taxonomy Term types

### DIFF
--- a/src/Entity/PropertyMapper.php
+++ b/src/Entity/PropertyMapper.php
@@ -102,14 +102,12 @@ class PropertyMapper extends CrudQueue {
    * @return array|null
    */
   public static function getConfig($type, $bundle) {
-    // Default the Taxonomy Term bundle to generic vocabulary.
-    if ($type == 'taxonomy_term') {
-      $bundle = 'vocabulary';
-    }
     $paths = module_invoke_all('aws_sqs_entity_property_mapper_config_paths');
     $file_pattern = join('.', [$type, $bundle, 'yml']);
+    $file_pattern_alt = join('.', [$type, 'yml']);
     foreach ($paths as $path) {
       $filename = join('/', [$path, $file_pattern]);
+      $filename_alt = join('/', [$path, $file_pattern_alt]);
       if (file_exists($filename)) {
         // @todo Look deeper at Symfony/Component/Yaml/Yaml::parse bitwise
         //   operators. Quick test of PARSE_OBJECT_FOR_MAP and PARSE_OBJECT
@@ -119,6 +117,10 @@ class PropertyMapper extends CrudQueue {
 
         // The first file found wins.
         return Yaml::parse(file_get_contents($filename));
+      }
+      // If no yml exists for the Bundle, look for a Type specific yml.
+      elseif (file_exists($filename_alt)) {
+        return Yaml::parse(file_get_contents($filename_alt));
       }
     }
   }

--- a/src/Entity/PropertyMapper.php
+++ b/src/Entity/PropertyMapper.php
@@ -102,6 +102,10 @@ class PropertyMapper extends CrudQueue {
    * @return array|null
    */
   public static function getConfig($type, $bundle) {
+    // Default the Taxonomy Term bundle to generic vocabulary.
+    if ($type == 'taxonomy_term') {
+      $bundle = 'vocabulary';
+    }
     $paths = module_invoke_all('aws_sqs_entity_property_mapper_config_paths');
     $file_pattern = join('.', [$type, $bundle, 'yml']);
     foreach ($paths as $path) {

--- a/src/Entity/PropertyMapper.php
+++ b/src/Entity/PropertyMapper.php
@@ -104,10 +104,10 @@ class PropertyMapper extends CrudQueue {
   public static function getConfig($type, $bundle) {
     $paths = module_invoke_all('aws_sqs_entity_property_mapper_config_paths');
     $file_pattern = join('.', [$type, $bundle, 'yml']);
-    $file_pattern_alt = join('.', [$type, 'yml']);
+    $file_pattern_type = join('.', [$type, 'yml']);
     foreach ($paths as $path) {
       $filename = join('/', [$path, $file_pattern]);
-      $filename_alt = join('/', [$path, $file_pattern_alt]);
+      $filename_type = join('/', [$path, $file_pattern_type]);
       if (file_exists($filename)) {
         // @todo Look deeper at Symfony/Component/Yaml/Yaml::parse bitwise
         //   operators. Quick test of PARSE_OBJECT_FOR_MAP and PARSE_OBJECT
@@ -119,8 +119,8 @@ class PropertyMapper extends CrudQueue {
         return Yaml::parse(file_get_contents($filename));
       }
       // If no yml exists for the Bundle, look for a Type specific yml.
-      elseif (file_exists($filename_alt)) {
-        return Yaml::parse(file_get_contents($filename_alt));
+      elseif (file_exists($filename_type)) {
+        return Yaml::parse(file_get_contents($filename_type));
       }
     }
   }


### PR DESCRIPTION
With the current `getConfig` logic, a different yml file is needed when trying to publish taxonomy terms from different vocabularies. This PR changes the `$bundle` from the vocabulary machine name to a generic `vocabulary`, so that only one yml file is required for all taxonomy terms, regardless of vocabulary.